### PR TITLE
feat: override operators in lua_State struct

### DIFF
--- a/src/Lua51.cs
+++ b/src/Lua51.cs
@@ -10,6 +10,37 @@ namespace LuaNET.Lua51;
 public struct lua_State
 {
 	public nuint Handle;
+
+    #region Override Methods
+
+    public bool IsNull() => Handle == 0;
+
+    public bool IsNotNull() => Handle != 0;
+
+    public static bool operator !(lua_State state) => state.IsNull();
+
+    public static bool operator ==(lua_State obj1, lua_State obj2)
+    {
+        if (ReferenceEquals(obj1.Handle, obj2.Handle))
+            return true;
+        if (ReferenceEquals(obj1.Handle, 0))
+            return false;
+        if (ReferenceEquals(obj2.Handle, 0))
+            return false;
+        return obj1.Handle.Equals(obj2.Handle);
+    }
+    public static bool operator !=(lua_State obj1, lua_State obj2) => !(obj1.Handle == obj2.Handle);
+
+    public int GetHashCode()
+    {
+        unchecked
+        {
+            int hashCode = Handle.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    #endregion
 }
 
 public static class Lua

--- a/src/Lua52.cs
+++ b/src/Lua52.cs
@@ -11,6 +11,37 @@ namespace LuaNET.Lua52;
 public struct lua_State
 {
 	public nuint Handle;
+
+    #region Override Methods
+
+    public bool IsNull() => Handle == 0;
+
+    public bool IsNotNull() => Handle != 0;
+
+    public static bool operator !(lua_State state) => state.IsNull();
+
+    public static bool operator ==(lua_State obj1, lua_State obj2)
+    {
+        if (ReferenceEquals(obj1.Handle, obj2.Handle))
+            return true;
+        if (ReferenceEquals(obj1.Handle, 0))
+            return false;
+        if (ReferenceEquals(obj2.Handle, 0))
+            return false;
+        return obj1.Handle.Equals(obj2.Handle);
+    }
+    public static bool operator !=(lua_State obj1, lua_State obj2) => !(obj1.Handle == obj2.Handle);
+
+    public int GetHashCode()
+    {
+        unchecked
+        {
+            int hashCode = Handle.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    #endregion
 }
 
 public static class Lua

--- a/src/Lua53.cs
+++ b/src/Lua53.cs
@@ -11,6 +11,37 @@ namespace LuaNET.Lua53;
 public struct lua_State
 {
 	public nuint Handle;
+
+    #region Override Methods
+
+    public bool IsNull() => Handle == 0;
+
+    public bool IsNotNull() => Handle != 0;
+
+    public static bool operator !(lua_State state) => state.IsNull();
+
+    public static bool operator ==(lua_State obj1, lua_State obj2)
+    {
+        if (ReferenceEquals(obj1.Handle, obj2.Handle))
+            return true;
+        if (ReferenceEquals(obj1.Handle, 0))
+            return false;
+        if (ReferenceEquals(obj2.Handle, 0))
+            return false;
+        return obj1.Handle.Equals(obj2.Handle);
+    }
+    public static bool operator !=(lua_State obj1, lua_State obj2) => !(obj1.Handle == obj2.Handle);
+
+    public int GetHashCode()
+    {
+        unchecked
+        {
+            int hashCode = Handle.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    #endregion
 }
 
 public struct lua_KContext

--- a/src/Lua54.cs
+++ b/src/Lua54.cs
@@ -11,6 +11,37 @@ namespace LuaNET.Lua54;
 public struct lua_State
 {
 	public nuint Handle;
+
+    #region Override Methods
+
+    public bool IsNull() => Handle == 0;
+
+    public bool IsNotNull() => Handle != 0;
+
+    public static bool operator !(lua_State state) => state.IsNull();
+
+    public static bool operator ==(lua_State obj1, lua_State obj2)
+    {
+        if (ReferenceEquals(obj1.Handle, obj2.Handle))
+            return true;
+        if (ReferenceEquals(obj1.Handle, 0))
+            return false;
+        if (ReferenceEquals(obj2.Handle, 0))
+            return false;
+        return obj1.Handle.Equals(obj2.Handle);
+    }
+    public static bool operator !=(lua_State obj1, lua_State obj2) => !(obj1.Handle == obj2.Handle);
+
+    public int GetHashCode()
+    {
+        unchecked
+        {
+            int hashCode = Handle.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    #endregion
 }
 
 public struct lua_KContext

--- a/src/LuaJIT.cs
+++ b/src/LuaJIT.cs
@@ -10,6 +10,37 @@ namespace LuaNET.LuaJIT;
 public struct lua_State
 {
 	public nuint Handle;
+
+    #region Override Methods
+
+    public bool IsNull() => Handle == 0;
+
+    public bool IsNotNull() => Handle != 0;
+
+    public static bool operator !(lua_State state) =>  state.IsNull();
+
+    public static bool operator ==(lua_State obj1, lua_State obj2)
+    {
+        if (ReferenceEquals(obj1.Handle, obj2.Handle))
+            return true;
+        if (ReferenceEquals(obj1.Handle, 0))
+            return false;
+        if (ReferenceEquals(obj2.Handle, 0))
+            return false;
+        return obj1.Handle.Equals(obj2.Handle);
+    }
+    public static bool operator !=(lua_State obj1, lua_State obj2) => !(obj1.Handle == obj2.Handle);
+
+    public int GetHashCode()
+    {
+        unchecked
+        {
+            int hashCode = Handle.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    #endregion
 }
 
 public static class Lua


### PR DESCRIPTION
Override operators in lua_State struct to facilitate use in comparations.

Without operators override:

``` cs
lua_State L = luaL_newstate();
if (L.Handle == 0)
	Console.WriteLine("Unable to create context!");
```

With operators override:

``` cs
lua_State L = luaL_newstate();
if (!L)
	Console.WriteLine("Unable to create context!");
```